### PR TITLE
FIX Reporter output file (creates directory)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "grunt-contrib-clean": "1.0.0",
     "grunt-http-server": "2.0.0",
     "gruntify-eslint": "3.1.0",
+    "mkdirp": "0.5.1",
     "testcafe": "0.14.0",
     "testcafe-reporter-xunit": "2.1.0"
   },

--- a/tasks/testcafe.js
+++ b/tasks/testcafe.js
@@ -9,6 +9,8 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
 const createTestCafe = require('testcafe');
 
 const DEFAULT_OPTS = {
@@ -56,6 +58,7 @@ module.exports = (grunt) => {
             })
             .then(() => {
                 if (opts.reporterOutputFile) {
+                    mkdirp.sync(path.dirname(opts.reporterOutputFile));
                     stream = fs.createWriteStream(opts.reporterOutputFile);
                 }
 


### PR DESCRIPTION
The reporter output file is now created successfully even if the path to the file does not exist.